### PR TITLE
feat: Android 8 (API 26) support — NDK retarget, devtmpfs fix, LF normalization, mount hardening

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,69 @@
+# Normalize line endings for files that run in Linux contexts.
+# All shell scripts, init files, and Linux config files MUST have LF endings;
+# Windows CRLF line endings break shebang parsing and OpenRC service scripts.
+
+# Default: let git auto-detect text vs binary
+* text=auto
+
+# Force LF for all shell scripts and Linux-targeted text files
+*.sh            text eol=lf
+*.c             text eol=lf
+*.h             text eol=lf
+Dockerfile*     text eol=lf
+Makefile*       text eol=lf
+*.mk            text eol=lf
+*.conf          text eol=lf
+*.md            text eol=lf
+*.txt           text eol=lf
+*.gradle        text eol=lf
+*.kts           text eol=lf
+*.kt            text eol=lf
+*.java          text eol=lf
+*.xml           text eol=lf
+*.json          text eol=lf
+*.yaml          text eol=lf
+*.yml           text eol=lf
+*.toml          text eol=lf
+*.properties    text eol=lf
+*.config        text eol=lf
+
+# Explicitly force LF for files without extensions that are Linux scripts
+init-podroid                                    text eol=lf
+build-rootfs/files/etc/init.d/podroid-bootstrap text eol=lf
+build-rootfs/files/etc/init.d/podroid-network   text eol=lf
+build-rootfs/files/etc/init.d/podroid-ready     text eol=lf
+build-rootfs/files/etc/init.d/podroid-resize    text eol=lf
+build-rootfs/files/etc/init.d/podroid-x11       text eol=lf
+build-rootfs/files/etc/init.d/podroid-vsock     text eol=lf
+build-rootfs/files/etc/init.d/podroid-hostd     text eol=lf
+build-rootfs/files/etc/init.d/podroid-migrate   text eol=lf
+build-rootfs/files/etc/inittab                  text eol=lf
+build-rootfs/files/etc/rc.conf                  text eol=lf
+build-rootfs/files/etc/conf.d/podroid           text eol=lf
+build-rootfs/files/usr/local/bin/podroid-getty  text eol=lf
+build-rootfs/files/usr/local/bin/podroid-login  text eol=lf
+build-rootfs/files/usr/local/bin/podroid-resize text eol=lf
+build-rootfs/files/etc/podroid/forwards.conf    text eol=lf
+
+# Binary assets — never convert
+*.squashfs      binary
+*.img           binary
+*.so            binary
+*.png           binary
+*.jpg           binary
+*.jpeg          binary
+*.gif           binary
+*.webp          binary
+*.ico           binary
+*.ttf           binary
+*.otf           binary
+*.woff          binary
+*.woff2         binary
+*.apk           binary
+*.jks           binary
+*.keystore      binary
+*.zip           binary
+*.gz            binary
+*.bz2           binary
+*.xz            binary
+*.zst           binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code (and any AI assistant or new contributor) working in th
 
 ## What Is This
 
-Podroid is an Android app that runs a real **Alpine 3.23** Linux VM on stock Android 9+ (arm64) to provide rootless **Podman / Docker / LXC** containers and an in-app **X11 desktop** - no root, no custom recovery.
+Podroid is an Android app that runs a real **Alpine 3.23** Linux VM on stock Android 8+ (arm64) to provide rootless **Podman / Docker / LXC** containers and an in-app **X11 desktop** - no root, no custom recovery.
 
 - **Two interchangeable VM backends** behind one interface (`VmEngine`):
   - **QEMU (TCG)** - software emulation, the default, needs no special permission.
@@ -18,7 +18,7 @@ Podroid is an Android app that runs a real **Alpine 3.23** Linux VM on stock And
 |---|---|
 | Package | `com.excp.podroid` (debug: `com.excp.podroid.debug`) |
 | Version | `versionName` / `versionCode` in `app/build.gradle.kts` |
-| Min / target SDK | 28 (Android 9) / 36 |
+| Min / target SDK | 26 (Android 8) / 36 |
 | Architecture | arm64 (`aarch64`) only |
 | Guest | Alpine 3.23 squashfs + persistent ext4 overlay, OpenRC PID 1 |
 | Kernel | custom Linux, version pinned by `podroidKernelVersion` in `gradle.properties` |
@@ -166,6 +166,8 @@ Single-activity Compose app: `ui/navigation/NavGraph.kt` routes `setup → home 
 ├── podroid-bridge.c                     # PTY <-> virtio-console relay -> libpodroid-bridge.so
 ├── podroid-launcher.c                   # exec wrapper that ties QEMU's lifetime to the app -> libpodroid-launcher.so
 ├── Dockerfile                           # kernel + initramfs + QEMU build
+├── build-tools/                         # static assets used during Docker builds
+│   └── cross-android-aarch64.ini        # Meson cross-compilation config for aarch64-android26
 ├── build-rootfs/
 │   ├── Dockerfile.rootfs, build-rootfs.sh
 │   ├── vsock-agent/                     # podroid-vsock-agent.c (AVF control/forward agent)
@@ -207,6 +209,9 @@ In `QemuEngine.buildCommand()`: `tcg,thread=multi`, larger `tb-size` for ≥2GB 
 
 ## Quirks & gotchas
 
+- **`CONFIG_DEVTMPFS_MOUNT=y` pre-mounts `/dev` before `/init` runs.** `init-podroid` must use `mount ... || true` for the devtmpfs line — the kernel's pre-populated `/dev` is sufficient and a second `mount(2)` returns EBUSY. Also: `size=` is not valid for devtmpfs in kernels where it is ramfs-backed (causes EINVAL). Either failure exits util-linux with `MNT_EX_FAIL=32`; `set -e` propagates `exit(32)`, encoded as `exitcode=0x00002000` ("Attempted to kill init!"). Always keep the `|| true`.
+- **util-linux `mount` stops option parsing at the first non-option argument** when `POSIXLY_CORRECT` is set. Put `-o` flags *before* device and mountpoint (`mount -t proc -o noexec,nosuid,nodev proc /proc`), not after. Options placed after the mountpoint are silently dropped, causing `mount(2)` to be called with `flags=0` and returning EPERM — which util-linux prints as "must be superuser to use mount" even for root.
+- **`Dockerfile` heredoc gotcha.** Docker BuildKit's parser treats `[section]` lines inside `RUN ... << 'EOF'` heredocs as unknown Dockerfile instructions and aborts the parse. Instead of using shell heredocs in `RUN` for multi-line config files, use `COPY build-tools/<file>` from the build context. The Meson cross-compilation config lives in `build-tools/cross-android-aarch64.ini` for this reason.
 - **Backend asymmetry is the #1 source of bugs.** QEMU = SLIRP + QMP + virtio-console (TTY); AVF = DHCP + vsock (raw sockets). Test both. The host bridge's `cfmakeraw` on hvc2 (above) is a concrete example.
 - **Boot detection** scans a rolling buffer, not per-read chunks (fast devices split markers).
 - **Bridge stderr is silenced** (`dup2(/dev/null, STDERR)`): it runs as a `TerminalSession` subprocess whose stderr IS the PTY. Never add `fprintf(stderr, ...)` to `podroid-bridge.c`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,8 @@ Podroid/
 ├── init-podroid                          Minimal initramfs script (~45 lines)
 ├── podroid-bridge.c                      Native PTY ↔ virtio-console relay
 ├── Dockerfile                            Kernel + initramfs + QEMU build pipeline
+├── build-tools/                          Static assets used during Docker builds
+│   └── cross-android-aarch64.ini         Meson cross-compilation config for aarch64-android26
 ├── build-rootfs/                         Alpine squashfs build pipeline
 │   ├── Dockerfile.rootfs
 │   ├── build-rootfs.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ You will need:
 - **Docker 20.10+** for the kernel, initramfs, rootfs, and QEMU build pipelines
 - **Android NDK r27c** for the bridge and Termux native libraries
 - **Android SDK** with platform 36 + build-tools
-- An **arm64 Android device** running **Android 9.0+ (API 28)** for testing
+- An **arm64 Android device** running **Android 8.0+ (API 26)** for testing
 
 ## Build pipeline
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -227,28 +227,7 @@ RUN printf '#!/bin/sh\nexport PKG_CONFIG_LIBDIR=/opt/deps/lib/pkgconfig\nexport 
     > /usr/local/bin/aarch64-android-pkg-config && chmod +x /usr/local/bin/aarch64-android-pkg-config \
     && ln -s /usr/local/bin/aarch64-android-pkg-config ${LLVM}/bin/llvm-pkg-config
 
-RUN cat > /opt/cross-android-aarch64.ini << 'EOF'
-[binaries]
-c = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang'
-cpp = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang++'
-ar = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
-strip = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip'
-ranlib = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib'
-nm = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-nm'
-pkg-config = '/usr/local/bin/aarch64-android-pkg-config'
-[properties]
-sys_root = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot'
-pkg_config_libdir = ['/opt/deps/lib/pkgconfig']
-c_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-I/opt/deps/include', '-fPIC', '-O2', '-march=armv8-a']
-cpp_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-I/opt/deps/include', '-fPIC', '-O2', '-march=armv8-a']
-c_link_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-L/opt/deps/lib', '-Wl,-z,max-page-size=16384']
-cpp_link_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-L/opt/deps/lib', '-Wl,-z,max-page-size=16384']
-[host_machine]
-system = 'linux'
-cpu_family = 'aarch64'
-cpu = 'aarch64'
-endian = 'little'
-EOF
+COPY build-tools/cross-android-aarch64.ini /opt/cross-android-aarch64.ini
 
 # Deps (pcre2, libffi, libiconv, glib, pixman, libattr, libucontext)
 RUN wget -q https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.44/pcre2-10.44.tar.gz && tar xf pcre2-10.44.tar.gz && cd pcre2-10.44 && ./configure --host=aarch64-linux-android --prefix=${PREFIX} --enable-static --disable-shared CC="${CC}" && make -j$(nproc) install

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,7 +219,7 @@ RUN pip3 install --break-system-packages meson 2>/dev/null || pip3 install meson
 RUN wget -q https://dl.google.com/android/repository/android-ndk-r27c-linux.zip -O /tmp/ndk.zip \
     && unzip -q /tmp/ndk.zip -d /opt && mv /opt/android-ndk-r27c /opt/ndk && rm /tmp/ndk.zip
 ENV NDK=/opt/ndk LLVM=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64 PREFIX=/opt/deps
-ENV CC="${LLVM}/bin/aarch64-linux-android28-clang" AR="${LLVM}/bin/llvm-ar" RANLIB="${LLVM}/bin/llvm-ranlib"
+ENV CC="${LLVM}/bin/aarch64-linux-android26-clang" AR="${LLVM}/bin/llvm-ar" RANLIB="${LLVM}/bin/llvm-ranlib"
 RUN mkdir -p ${PREFIX}/{lib,include,lib/pkgconfig}
 
 # Cross-compilation setup
@@ -229,8 +229,8 @@ RUN printf '#!/bin/sh\nexport PKG_CONFIG_LIBDIR=/opt/deps/lib/pkgconfig\nexport 
 
 RUN cat > /opt/cross-android-aarch64.ini << 'EOF'
 [binaries]
-c = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang'
-cpp = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang++'
+c = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang'
+cpp = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang++'
 ar = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
 strip = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip'
 ranlib = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib'
@@ -239,10 +239,10 @@ pkg-config = '/usr/local/bin/aarch64-android-pkg-config'
 [properties]
 sys_root = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot'
 pkg_config_libdir = ['/opt/deps/lib/pkgconfig']
-c_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android28', '-I/opt/deps/include', '-fPIC', '-O2', '-march=armv8-a']
-cpp_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android28', '-I/opt/deps/include', '-fPIC', '-O2', '-march=armv8-a']
-c_link_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android28', '-L/opt/deps/lib', '-Wl,-z,max-page-size=16384']
-cpp_link_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android28', '-L/opt/deps/lib', '-Wl,-z,max-page-size=16384']
+c_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-I/opt/deps/include', '-fPIC', '-O2', '-march=armv8-a']
+cpp_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-I/opt/deps/include', '-fPIC', '-O2', '-march=armv8-a']
+c_link_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-L/opt/deps/lib', '-Wl,-z,max-page-size=16384']
+cpp_link_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-L/opt/deps/lib', '-Wl,-z,max-page-size=16384']
 [host_machine]
 system = 'linux'
 cpu_family = 'aarch64'
@@ -250,12 +250,19 @@ cpu = 'aarch64'
 endian = 'little'
 EOF
 
-# Deps (pcre2, libffi, glib, pixman, libattr, libucontext)
+# Deps (pcre2, libffi, libiconv, glib, pixman, libattr, libucontext)
 RUN wget -q https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.44/pcre2-10.44.tar.gz && tar xf pcre2-10.44.tar.gz && cd pcre2-10.44 && ./configure --host=aarch64-linux-android --prefix=${PREFIX} --enable-static --disable-shared CC="${CC}" && make -j$(nproc) install
 RUN wget -q https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz && tar xf libffi-3.4.6.tar.gz && cd libffi-3.4.6 && ./configure --host=aarch64-linux-android --prefix=${PREFIX} --enable-static --disable-shared CC="${CC}" && make -j$(nproc) install
-RUN wget -q https://download.gnome.org/sources/glib/2.82/glib-2.82.5.tar.xz && tar xf glib-2.82.5.tar.xz && cd glib-2.82.5 && meson setup _build --cross-file /opt/cross-android-aarch64.ini --prefix ${PREFIX} --default-library static -Dselinux=disabled -Dlibmount=disabled && ninja -C _build install
+# API-26 Bionic lacks iconv symbols in libc. Provide a tiny libiconv shim so
+# glib can link in the cross build. It implements byte-for-byte passthrough.
+RUN printf '#ifndef PODROID_ICONV_H\n#define PODROID_ICONV_H\n#include <stddef.h>\ntypedef void *iconv_t;\niconv_t iconv_open(const char *tocode, const char *fromcode);\nsize_t iconv(iconv_t cd, char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft);\nint iconv_close(iconv_t cd);\n#endif\n' > ${PREFIX}/include/iconv.h \
+    && printf '#include <errno.h>\n#include <stddef.h>\n#include <string.h>\n#include <iconv.h>\niconv_t iconv_open(const char *tocode, const char *fromcode) {\n    if (!tocode || !fromcode) { errno = EINVAL; return (iconv_t)-1; }\n    return (iconv_t)1;\n}\nsize_t iconv(iconv_t cd, char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft) {\n    (void)cd;\n    if (!inbuf || !inbytesleft || !outbuf || !outbytesleft) { errno = EINVAL; return (size_t)-1; }\n    if (!*inbuf || *inbytesleft == 0) return 0;\n    if (!*outbuf || *outbytesleft == 0) { errno = E2BIG; return (size_t)-1; }\n    size_t n = (*inbytesleft < *outbytesleft) ? *inbytesleft : *outbytesleft;\n    memcpy(*outbuf, *inbuf, n);\n    *inbuf += n;\n    *outbuf += n;\n    *inbytesleft -= n;\n    *outbytesleft -= n;\n    if (*inbytesleft != 0) { errno = E2BIG; return (size_t)-1; }\n    return 0;\n}\nint iconv_close(iconv_t cd) {\n    (void)cd;\n    return 0;\n}\n' > /tmp/iconv_shim.c \
+    && ${CC} --sysroot=${LLVM}/sysroot -target aarch64-linux-android26 -I${PREFIX}/include -c /tmp/iconv_shim.c -o /tmp/iconv_shim.o \
+    && ${AR} rcs ${PREFIX}/lib/libiconv.a /tmp/iconv_shim.o \
+    && cp ${PREFIX}/lib/libiconv.a ${LLVM}/sysroot/usr/lib/aarch64-linux-android/26/libiconv.a
+RUN wget -q https://download.gnome.org/sources/glib/2.82/glib-2.82.5.tar.xz&& tar xf glib-2.82.5.tar.xz && cd glib-2.82.5 && meson setup _build --cross-file /opt/cross-android-aarch64.ini --prefix ${PREFIX} --default-library static -Dselinux=disabled -Dlibmount=disabled && ninja -C _build install
 RUN wget -q https://cairographics.org/releases/pixman-0.44.2.tar.xz && tar xf pixman-0.44.2.tar.xz && cd pixman-0.44.2 && meson setup _build --cross-file /opt/cross-android-aarch64.ini --prefix ${PREFIX} --default-library static -Da64-neon=disabled && ninja -C _build install
-RUN wget -q https://download.savannah.gnu.org/releases/attr/attr-2.5.2.tar.gz && tar xf attr-2.5.2.tar.gz && cd attr-2.5.2 && ./configure --host=aarch64-linux-android --prefix=${PREFIX} --enable-static --disable-shared CC="${CC}" && make -j$(nproc) install && cp ${PREFIX}/lib/libattr.a ${LLVM}/sysroot/usr/lib/aarch64-linux-android/28/libattr.a
+RUN wget -q https://download.savannah.gnu.org/releases/attr/attr-2.5.2.tar.gz && tar xf attr-2.5.2.tar.gz && cd attr-2.5.2 && ./configure --host=aarch64-linux-android --prefix=${PREFIX} --enable-static --disable-shared CC="${CC}" && make -j$(nproc) install && cp ${PREFIX}/lib/libattr.a ${LLVM}/sysroot/usr/lib/aarch64-linux-android/26/libattr.a
 RUN git clone --depth=1 https://github.com/kaniini/libucontext.git /tmp/libucontext && make -C /tmp/libucontext ARCH=aarch64 CC="${CC}" EXPORT_UNPREFIXED=yes && install -Dm644 /tmp/libucontext/libucontext.a ${PREFIX}/lib/libucontext.a && install -Dm644 /tmp/libucontext/include/libucontext/libucontext.h ${PREFIX}/include/libucontext/libucontext.h && install -Dm644 /tmp/libucontext/arch/common/include/libucontext/bits.h ${PREFIX}/include/libucontext/bits.h \
     && printf '#ifndef PODROID_UCONTEXT_SHIM_H\n#define PODROID_UCONTEXT_SHIM_H\n#include_next <ucontext.h>\n#include <libucontext/libucontext.h>\n#define getcontext libucontext_getcontext\n#define makecontext libucontext_makecontext\n#define setcontext libucontext_setcontext\n#define swapcontext libucontext_swapcontext\n#endif\n' > ${PREFIX}/include/ucontext.h
 
@@ -275,14 +282,14 @@ RUN printf '#undef st_atime_nsec\n#undef st_mtime_nsec\n#undef st_ctime_nsec\n' 
 # ivshmem-{server,client} also call shm_open; stub their meson.build files since we don't ship them
 RUN printf '# disabled for Android Bionic\n' > ${QEMU_DIR}/contrib/ivshmem-server/meson.build \
     && printf '# disabled for Android Bionic\n' > ${QEMU_DIR}/contrib/ivshmem-client/meson.build
-# shm_open/shm_unlink are absent from the NDK API-28 stubs.
+# shm_open/shm_unlink are absent from the NDK API-26 stubs.
 # Shim header: forward-declares them for all QEMU TUs.
 # libshm.a: provides an implementation via memfd_create (works on all Android 8+ kernels).
 RUN printf '#ifndef PODROID_SHM_SHIM_H\n#define PODROID_SHM_SHIM_H\nextern int shm_open(const char *, int, unsigned);\nextern int shm_unlink(const char *);\n#endif\n' \
     > /opt/shm_shim.h
 RUN printf '#include <sys/syscall.h>\n#include <unistd.h>\n#include <errno.h>\n#ifndef SYS_memfd_create\n#define SYS_memfd_create 279\n#endif\nint shm_open(const char *n, int f, unsigned m) {\n    (void)f; (void)m;\n    while (*n == '"'"'/'"'"') n++;\n    long fd = syscall(SYS_memfd_create, n, 0);\n    if (fd < 0) { errno = (int)(-fd); return -1; }\n    return (int)fd;\n}\nint shm_unlink(const char *n) { (void)n; return 0; }\n' \
     > /tmp/shm_stub.c \
-    && ${CC} --sysroot=${LLVM}/sysroot -target aarch64-linux-android28 -c /tmp/shm_stub.c -o /tmp/shm_stub.o \
+    && ${CC} --sysroot=${LLVM}/sysroot -target aarch64-linux-android26 -c /tmp/shm_stub.c -o /tmp/shm_stub.o \
     && ${AR} rcs ${PREFIX}/lib/libshm.a /tmp/shm_stub.o
 
 # coroutine sigsetjmp shim — Bionic's sigsetjmp uses PAC instructions (paciasp /
@@ -294,7 +301,7 @@ RUN printf '#include <sys/syscall.h>\n#include <unistd.h>\n#include <errno.h>\n#
 # no syscalls, no stack-protector wrapping. ~22 doublewords -> fits in sigjmp_buf.
 RUN printf '#ifndef PODROID_QEMU_JMP_H\n#define PODROID_QEMU_JMP_H\n#include <setjmp.h>\nextern int _qemu_setjmp(sigjmp_buf);\n__attribute__((noreturn)) extern void _qemu_longjmp(sigjmp_buf, int);\n#endif\n' > /opt/qemu_jmp.h \
     && printf '.text\n.global _qemu_setjmp\n.type _qemu_setjmp,%%function\n_qemu_setjmp:\nstp x19,x20,[x0,#0]\nstp x21,x22,[x0,#16]\nstp x23,x24,[x0,#32]\nstp x25,x26,[x0,#48]\nstp x27,x28,[x0,#64]\nstp x29,x30,[x0,#80]\nmov x9,sp\nstr x9,[x0,#96]\nstp d8,d9,[x0,#104]\nstp d10,d11,[x0,#120]\nstp d12,d13,[x0,#136]\nstp d14,d15,[x0,#152]\nmov w0,#0\nret\n.size _qemu_setjmp,.-_qemu_setjmp\n.global _qemu_longjmp\n.type _qemu_longjmp,%%function\n_qemu_longjmp:\nldp x19,x20,[x0,#0]\nldp x21,x22,[x0,#16]\nldp x23,x24,[x0,#32]\nldp x25,x26,[x0,#48]\nldp x27,x28,[x0,#64]\nldp x29,x30,[x0,#80]\nldr x9,[x0,#96]\nmov sp,x9\nldp d8,d9,[x0,#104]\nldp d10,d11,[x0,#120]\nldp d12,d13,[x0,#136]\nldp d14,d15,[x0,#152]\ncmp w1,#0\ncsinc w0,w1,wzr,ne\nbr x30\n.size _qemu_longjmp,.-_qemu_longjmp\n.section .note.GNU-stack,"",%%progbits\n' > /tmp/qemu_jmp.S \
-    && ${CC} --sysroot=${LLVM}/sysroot -target aarch64-linux-android28 -c /tmp/qemu_jmp.S -o /tmp/qemu_jmp.o \
+    && ${CC} --sysroot=${LLVM}/sysroot -target aarch64-linux-android26 -c /tmp/qemu_jmp.S -o /tmp/qemu_jmp.o \
     && ${AR} rcs ${PREFIX}/lib/libqemujmp.a /tmp/qemu_jmp.o
 
 # Patch coroutine-ucontext.c to call our PAC-free shim instead of libc's sigsetjmp/siglongjmp.
@@ -314,11 +321,11 @@ RUN cd ${QEMU_DIR} && ./configure --cc="${CC}" --cross-prefix="${LLVM}/bin/llvm-
 
 # Bridge
 COPY podroid-bridge.c /tmp/podroid-bridge.c
-RUN ${CC} --sysroot=${LLVM}/sysroot -target aarch64-linux-android28 -fPIE -pie -Wl,-z,max-page-size=16384 /tmp/podroid-bridge.c -o /opt/qemu-out/libpodroid-bridge.so
+RUN ${CC} --sysroot=${LLVM}/sysroot -target aarch64-linux-android26 -fPIE -pie -Wl,-z,max-page-size=16384 /tmp/podroid-bridge.c -o /opt/qemu-out/libpodroid-bridge.so
 
 # Launcher (PR_SET_PDEATHSIG wrapper for QEMU — see podroid-launcher.c)
 COPY podroid-launcher.c /tmp/podroid-launcher.c
-RUN ${CC} --sysroot=${LLVM}/sysroot -target aarch64-linux-android28 -fPIE -pie -Wl,-z,max-page-size=16384 /tmp/podroid-launcher.c -o /opt/qemu-out/libpodroid-launcher.so
+RUN ${CC} --sysroot=${LLVM}/sysroot -target aarch64-linux-android26 -fPIE -pie -Wl,-z,max-page-size=16384 /tmp/podroid-launcher.c -o /opt/qemu-out/libpodroid-launcher.so
 
 # Soname fix
 RUN cp /opt/qemu-out/bin/qemu-system-aarch64 /opt/qemu-out/libqemu-system-aarch64.so \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A real Alpine Linux VM with its own kernel - not a chroot or proot trick - so **
 [![Downloads](https://img.shields.io/github/downloads/ExTV/Podroid/total?style=flat-square&color=brightgreen)](https://github.com/ExTV/Podroid/releases)
 [![Stars](https://img.shields.io/github/stars/ExTV/Podroid?style=flat-square&color=yellow)](https://github.com/ExTV/Podroid/stargazers)
 [![License](https://img.shields.io/github/license/ExTV/Podroid?style=flat-square)](LICENSE)
-![Android 9+](https://img.shields.io/badge/Android-9%2B-3DDC84?style=flat-square&logo=android&logoColor=white)
+![Android 8+](https://img.shields.io/badge/Android-8%2B-3DDC84?style=flat-square&logo=android&logoColor=white)
 ![arm64](https://img.shields.io/badge/arch-arm64-orange?style=flat-square)
 
 [**Website**](https://extv.github.io/Podroid/) · [**Documentation**](https://extv.github.io/Podroid/guide/) · [**Download APK**](https://github.com/ExTV/Podroid/releases/latest)
@@ -35,7 +35,7 @@ A real Alpine Linux VM with its own kernel - not a chroot or proot trick - so **
 - **In-app terminal** - full xterm-256color, 122 color themes, 13 fonts, live resize
 - **X11 desktop** - run GUI Linux apps in a built-in viewer with touch, keyboard, mouse and audio
 - **USB passthrough**, **SSH**, **port forwarding** and a **guest-to-Android bridge**
-- **English and 中文**, no root, any arm64 device on Android 9+
+- **English and 中文**, no root, any arm64 device on Android 8+
 
 ## Quick start
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         applicationId = "com.excp.podroid"
-        minSdk = 28
+        minSdk = 26
         targetSdk = 36
         versionCode = 27
         versionName = "1.2.4"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
     <!-- Storage access for persistent container storage -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 
     <!-- Large heap for QEMU memory allocation -->
     <uses-feature android:name="android.hardware.opengles.aep" android:required="false" />

--- a/app/src/main/java/com/excp/podroid/engine/QemuEngine.kt
+++ b/app/src/main/java/com/excp/podroid/engine/QemuEngine.kt
@@ -552,9 +552,14 @@ class QemuEngine @Inject constructor(
         val downloadsDir = android.os.Environment.getExternalStoragePublicDirectory(
             android.os.Environment.DIRECTORY_DOWNLOADS
         )
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R &&
-            config.storageAccessEnabled &&
-            android.os.Environment.isExternalStorageManager() &&
+        val hasStorageAccess = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R)
+            android.os.Environment.isExternalStorageManager()
+        else
+            androidx.core.content.ContextCompat.checkSelfPermission(
+                context, android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+        if (config.storageAccessEnabled &&
+            hasStorageAccess &&
             downloadsDir.exists()) {
             // security_model=mapped-xattr keeps QEMU's 9p worker out of the
             // chmod/chown syscall path that has triggered SIGILL on Tensor /

--- a/app/src/main/java/com/excp/podroid/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/excp/podroid/ui/screens/settings/SettingsScreen.kt
@@ -1,10 +1,14 @@
 package com.excp.podroid.ui.screens.settings
 
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.core.content.ContextCompat
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -627,6 +631,7 @@ private fun DownloadsSharingRow(
 ) {
     val context = LocalContext.current
     val canManageAllFiles = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+    val writeStoragePermLauncher = rememberLauncherForActivityResult(RequestPermission()) { _ -> }
 
     @androidx.annotation.RequiresApi(Build.VERSION_CODES.R)
     fun openAllFilesAccessSettings() {
@@ -645,8 +650,16 @@ private fun DownloadsSharingRow(
                 checked = enabled && available,
                 onCheckedChange = { checked ->
                     onToggle(checked)
-                    if (checked && canManageAllFiles && !Environment.isExternalStorageManager()) {
-                        openAllFilesAccessSettings()
+                    if (checked) {
+                        if (canManageAllFiles && !Environment.isExternalStorageManager()) {
+                            openAllFilesAccessSettings()
+                        } else if (!canManageAllFiles &&
+                            ContextCompat.checkSelfPermission(
+                                context, android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+                            ) != PackageManager.PERMISSION_GRANTED
+                        ) {
+                            writeStoragePermLauncher.launch(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                        }
                     }
                 },
                 enabled = vmNotRunning && available,

--- a/app/src/main/java/com/excp/podroid/ui/screens/setup/SetupScreen.kt
+++ b/app/src/main/java/com/excp/podroid/ui/screens/setup/SetupScreen.kt
@@ -402,8 +402,21 @@ private fun StorageAccessPage(
     onBack: () -> Unit,
     onNext: () -> Unit,
 ) {
+    val context = LocalContext.current
     val canManageAllFiles = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
-    val hasStoragePermission = !canManageAllFiles || Environment.isExternalStorageManager()
+    var hasStoragePermission by remember {
+        mutableStateOf(
+            when {
+                canManageAllFiles -> Environment.isExternalStorageManager()
+                else -> ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.WRITE_EXTERNAL_STORAGE
+                ) == PackageManager.PERMISSION_GRANTED
+            }
+        )
+    }
+    val writeStoragePermLauncher = rememberLauncherForActivityResult(RequestPermission()) { granted ->
+        hasStoragePermission = granted
+    }
 
     SetupPageLayout(
         windowSizeClass = windowSizeClass,
@@ -425,9 +438,16 @@ private fun StorageAccessPage(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        if (storageAccessEnabled && canManageAllFiles && !hasStoragePermission) {
+        if (storageAccessEnabled && !hasStoragePermission) {
             Spacer(Modifier.height(PodroidTokens.Spacing.LG))
-            PodroidPrimaryButton(text = stringResource(R.string.grant_storage_access), onClick = onOpenStorageAccessSettings)
+            if (canManageAllFiles) {
+                PodroidPrimaryButton(text = stringResource(R.string.grant_storage_access), onClick = onOpenStorageAccessSettings)
+            } else {
+                PodroidPrimaryButton(
+                    text = stringResource(R.string.grant_storage_access),
+                    onClick = { writeStoragePermLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE) },
+                )
+            }
         }
         Spacer(Modifier.height(PodroidTokens.Spacing.LG))
         Text(

--- a/build-tools/cross-android-aarch64.ini
+++ b/build-tools/cross-android-aarch64.ini
@@ -1,0 +1,20 @@
+[binaries]
+c = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang'
+cpp = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang++'
+ar = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
+strip = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip'
+ranlib = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib'
+nm = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-nm'
+pkg-config = '/usr/local/bin/aarch64-android-pkg-config'
+[properties]
+sys_root = '/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot'
+pkg_config_libdir = ['/opt/deps/lib/pkgconfig']
+c_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-I/opt/deps/include', '-fPIC', '-O2', '-march=armv8-a']
+cpp_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-I/opt/deps/include', '-fPIC', '-O2', '-march=armv8-a']
+c_link_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-L/opt/deps/lib', '-Wl,-z,max-page-size=16384']
+cpp_link_args = ['--sysroot=/opt/ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot', '-target', 'aarch64-linux-android26', '-L/opt/deps/lib', '-Wl,-z,max-page-size=16384']
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'

--- a/init-podroid
+++ b/init-podroid
@@ -4,9 +4,31 @@
 # on the Alpine squashfs.
 set -e
 
-mount -t proc    proc      /proc  -o noexec,nosuid,nodev
-mount -t sysfs   sys       /sys   -o noexec,nosuid,nodev
-mount -t devtmpfs devtmpfs /dev   -o exec,nosuid,mode=0755,size=2M
+# Ensure mount points exist (defensive: cpio packing can omit empty dirs).
+mkdir -p /proc /sys /dev /run
+
+echo "[podroid-init] mounting virtual filesystems" > /dev/console
+
+# Place -o BEFORE the device and mountpoint arguments.
+# util-linux's getopt stops processing options at the first non-option
+# argument when POSIXLY_CORRECT is set; options placed after the mountpoint
+# are then treated as extra positional args, not flags, which can result in
+# the mount(2) syscall being called with flags=0 and returning EPERM,
+# producing "must be superuser to use mount" even for root.
+mount -t proc    -o noexec,nosuid,nodev     proc      /proc
+echo "[podroid-init] mounted /proc" > /dev/console
+mount -t sysfs   -o noexec,nosuid,nodev     sysfs     /sys
+echo "[podroid-init] mounted /sys" > /dev/console
+
+# CONFIG_DEVTMPFS_MOUNT=y causes the kernel to pre-mount devtmpfs at /dev
+# before executing /init.  A second mount(2) there can return EBUSY, and
+# size= is not a valid option for devtmpfs in kernels where it is backed by
+# ramfs rather than tmpfs, causing EINVAL.  Either failure exits util-linux
+# with MNT_EX_FAIL=32; set -e then propagates exit(32), which the kernel
+# encodes as exitcode=0x00002000 ("Attempted to kill init!").
+# The kernel's pre-populated /dev is sufficient; || true makes this non-fatal.
+mount -t devtmpfs -o exec,nosuid,mode=0755  devtmpfs  /dev || true
+echo "[podroid-init] mounted /dev (or reused kernel pre-mount)" > /dev/console
 
 echo "Mounting storage..." > /dev/console
 
@@ -90,4 +112,5 @@ mount --move /sys  /mnt/overlay/sys \
 mount --move /dev  /mnt/overlay/dev \
     || { echo "FATAL: mount --move /dev failed" > /dev/console; exec sh; }
 
+echo "[podroid-init] switching to real root" > /dev/console
 exec /sbin/switch_root /mnt/overlay /sbin/init

--- a/terminal-emulator/build.gradle.kts
+++ b/terminal-emulator/build.gradle.kts
@@ -7,7 +7,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 26
 
         externalNativeBuild {
             ndkBuild {

--- a/terminal-view/build.gradle.kts
+++ b/terminal-view/build.gradle.kts
@@ -7,7 +7,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 26
     }
 
     compileOptions {


### PR DESCRIPTION
## Summary

Extends minimum supported Android version from API 28 to **API 26 (Android 8.0)** by fixing four independent root causes that together prevented QEMU + the VM guest from working on API 26 devices.

Fixes: #28

---

## Commits

### 1. `feat: add Android 8 (API 26) support with iconv shim`

Retargets the NDK toolchain from `android28` to `android26` throughout the Dockerfile and adds a hand-rolled `iconv` shim required for the `glib` build at API 26 (where `iconv` is not in the NDK sysroot). Lowers `minSdk` to 26 in the Android project.

### 2. `fix(build): add .gitattributes to enforce LF line endings for Linux scripts`

Windows `git core.autocrlf=true` silently converted LF→CRLF on checkout. When Docker `COPY`'d `init-podroid` into the initramfs the shebang became `#!/bin/sh\r`, causing the kernel to fail init with `ENOENT` and fall back to mounting `/dev/vda` directly — booting stale overlay content with old `inittab` gettys instead of the current squashfs, so boot-stage markers were never emitted and the VM appeared stuck indefinitely.

- Added `.gitattributes`: `eol=lf` for all `*.sh`, `Dockerfile`, `init-podroid`, and `build-rootfs/files/**`; binary assets marked accordingly
- Normalized all affected working-copy files from CRLF to LF

### 3. `feat(init): enhance virtual filesystem mounting logic in init script`

Intermediate step hardening the early-boot mount sequence before the root-cause fix below.

### 4. `fix(build): fix devtmpfs boot panic, Dockerfile heredoc parse error, and Android 8 docs`

The definitive boot-panic fix, addressing three separate issues found during API 26 testing:

**devtmpfs mount panic (`exitcode=0x00002000` / `Attempted to kill init!`)**
- `util-linux mount` stops option parsing at the first non-option argument when `POSIXLY_CORRECT` is set; `-o` flags placed *after* the mountpoint were silently dropped, causing `EPERM` → `"must be superuser to use mount"` even for root
- `CONFIG_DEVTMPFS_MOUNT=y` pre-mounts `/dev` before `/init` runs; a second `mount` call returns `EBUSY`. Additionally, `size=2M` is invalid for ramfs-backed devtmpfs → `EINVAL`. Either failure exits with `MNT_EX_FAIL=32`, which `set -e` propagated as PID 1 exit → kernel panic
- **Fix:** move `-o` flags before device/mountpoint; add `|| true` to devtmpfs mount; remove `size=2M`; add `mkdir -p` guards; add `[podroid-init]` echo markers throughout

**Dockerfile heredoc parse error (Docker BuildKit)**
- `RUN cat > file << EOF ... [section]` heredocs were broken by BuildKit treating `[section]` lines as unknown build instructions
- **Fix:** replace the heredoc with `COPY build-tools/cross-android-aarch64.ini`; extract the Meson cross-compilation config to `build-tools/cross-android-aarch64.ini`

**Documentation**
- `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`: update Android min version `9+` → `8+`, add `build-tools/` to project layout, document the devtmpfs and Dockerfile quirks for future contributors

---

## Testing

| Device | Android | Result |
|---|---|---|
| Asus Zenfone 4 (Z01KD) | 8.0 (API 26), arm64 | ✅ Full boot; `Ready!` detected by `BootStageDetector` in ~55 s, no timeout fallback triggered |

The guest-side fixes (`init-podroid`, `.gitattributes`) are host-OS agnostic and require no API-level guards in the Android app.

---

## Checklist

- [x] Tested on a real arm64 device
- [x] `README.md` updated (user-facing: new minimum Android version)
- [x] `CLAUDE.md` updated (architecture change: NDK target, build-tools layout, devtmpfs behaviour)
- [x] `CONTRIBUTING.md` updated (min version, new `build-tools/` directory)
- [x] Code style matches surrounding files
- [x] No premature abstractions — each change is the smallest fix for its root cause